### PR TITLE
Add support for OS X 10.7

### DIFF
--- a/mac_os_x.sh
+++ b/mac_os_x.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# This bootstraps Puppet on Mac OS X 10.8.
+# This bootstraps Puppet on Mac OS X 10.8 and 10.7.
 #
 # Optional environmental variables:
 #   - FACTER_PACKAGE_URL: The URL to the Facter package to install.


### PR DESCRIPTION
This makes the OS X 10.8 script generic and renames it to indicate it supports more than just 10.8
