### PR TITLE
Put the unit file for the agent in the right place on Arch

### DIFF
--- a/arch.sh
+++ b/arch.sh
@@ -21,3 +21,5 @@ gem install puppet facter --no-ri --no-rdoc --no-user-install
 
 # Create the Puppet group so it can run
 groupadd puppet
+
+cp `gem contents puppet | grep puppetagent.service` /usr/lib/systemd/system


### PR DESCRIPTION
This copies the .service file from the gem into the appropriate place on
the system so that the only thing left for somebody to do to get puppet
started is run:

   systemctl enable puppetagent.service && systemctl start puppetagent
