### PR TITLE
Make centos_6_x.sh idempotent

### DIFF
--- a/centos_6_x.sh
+++ b/centos_6_x.sh
@@ -11,6 +11,11 @@ if [ "$EUID" -ne "0" ]; then
   exit 1
 fi
 
+if which puppet > /dev/null 2>&1; then
+  echo "Puppet is already installed."
+  exit 0
+fi
+
 # Install puppet labs repo
 echo "Configuring PuppetLabs repo..."
 repo_path=$(mktemp)


### PR DESCRIPTION
Previously, in the case where Puppet were already installed (whether you had
already booted the VM and were doing a `vagrant provision` again or whether
the box already had Puppet installed), the centos_6_x.sh provisioning script
would exit with a non-zero status:

```
package puppetlabs-release-6-6.noarch is already installed
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

chmod +x /tmp/vagrant-shell && /tmp/vagrant-shell
```

This is coming from `rpm -i ${repo_path} >/dev/null` which is exiting non-zero.
Exiting non-zero prohibits any other provisioners from running, which requires
you to destroy and re-create the VM or comment out this line in order to run
`vagrant provision` again.

This commit adds a check for Puppet using `which puppet` and redirecting
output to /dev/null. If Puppet is already installed, that message is echoed
and the script exits zero.
