### PR TITLE
Hide puppet user at loginwindow on Mac OS X

### DIFF
--- a/mac_os_x.sh
+++ b/mac_os_x.sh
@@ -59,3 +59,6 @@ install_dmg "Facter" ${FACTER_PACKAGE_URL}
 dscl . -create /groups/puppet
 dscl . -create /groups/puppet gid 1000
 dscl . -create /groups/puppet passwd '*'
+
+# Hide all users from the loginwindow with uid below 500, which will include the puppet user
+defaults write /Library/Preferences/com.apple.loginwindow Hide500Users -bool YES


### PR DESCRIPTION
The puppet install package will create a puppet user with a low uid.  This user will be shown at the loginwindow unless the Hide500Users key is ticketed.  

This is getting into configuration management, so I'm not sure if it's appropriate or not to include in the bootstrap.
