### PR TITLE
Select correct systemd service file instead of non-existent one

### DIFF
--- a/arch.sh
+++ b/arch.sh
@@ -22,4 +22,4 @@ gem install puppet facter --no-ri --no-rdoc --no-user-install
 # Create the Puppet group so it can run
 groupadd puppet
 
-cp `gem contents puppet | grep puppetagent.service` /usr/lib/systemd/system
+cp `gem contents puppet | grep puppet.service` /usr/lib/systemd/system


### PR DESCRIPTION
The existing code tries to copy a non-existent file to create a systemd service. 
This does not result in a service that starts at boot. Tested against an Arch vagrant box from http://iweb.dl.sourceforge.net/project/flowboard-vagrant-boxes/arch64-2013-07-26-minimal.box.
