### PR TITLE
Set repo arch to x86_64 for centos.

### DIFF
--- a/centos_6_x.sh
+++ b/centos_6_x.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-REPO_URL="http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-7.noarch.rpm"
+REPO_URL="http://yum.puppetlabs.com/el/6/products/x86_64/puppetlabs-release-6-7.noarch.rpm"
 
 if [ "$EUID" -ne "0" ]; then
   echo "This script must be run as root." >&2


### PR DESCRIPTION
The comments on the file for centos suggest that the target is 64-bit.  If that's the case, it probably makes sense to use the x86_64 puppet repo.