### PR TITLE
Updated puppetlabs noarch rpm url and reworked centos 6.x script to be more brief

### DIFF
--- a/centos_6_x.sh
+++ b/centos_6_x.sh
@@ -2,28 +2,22 @@
 # This bootstraps Puppet on CentOS 6.x
 # It has been tested on CentOS 6.4 64bit
 
-set -e
+repo="https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm"
 
-REPO_URL="http://yum.puppetlabs.com/el/6/products/i386/puppetlabs-release-6-7.noarch.rpm"
-
-if [ "$EUID" -ne "0" ]; then
-  echo "This script must be run as root." >&2
+[ "$EUID" -ne "0" ]                                     && \
+  echo "ERROR:  This script must be run as root." >&2   && \
   exit 1
-fi
 
-if which puppet > /dev/null 2>&1; then
-  echo "Puppet is already installed."
+which puppet &> /dev/null               && \
+  echo "Puppet is already installed."   && \
   exit 0
-fi
 
-# Install puppet labs repo
-echo "Configuring PuppetLabs repo..."
-repo_path=$(mktemp)
-wget --output-document="${repo_path}" "${REPO_URL}" 2>/dev/null
-rpm -i "${repo_path}" >/dev/null
-
-# Install Puppet...
-echo "Installing puppet"
-yum install -y puppet > /dev/null
-
-echo "Puppet installed!"
+for cmd in {"rpm -i ${repo}","yum install puppet"}; do
+  [ ! -z "${verbose}" ] && echo "$cmd"
+  $cmd
+  rc=$?
+  if [ "$rc" -ne "0" ]; then
+    echo "ERROR:  Command '$cmd' returned $exit_status"
+    exit $exit_status
+  fi
+done


### PR DESCRIPTION
Updated centos 6.x script to update puppetlabs noarch rpm url.  Also reworked bash script to be a bit more brief and a bit more informative when using the 'verbose' flag.  Usage:  verbose=1 centos_6_x.sh
