### PR TITLE
Suppress dialog to overwrite puppet configuration files in Ubuntu and Debian.

### DIFF
--- a/debian.sh
+++ b/debian.sh
@@ -37,6 +37,6 @@ apt-get update >/dev/null
 
 # Install Puppet
 echo "Installing Puppet..."
-apt-get install -y puppet >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install puppet >/dev/null
 
 echo "Puppet installed!"

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -39,7 +39,7 @@ apt-get update >/dev/null
 
 # Install Puppet
 echo "Installing Puppet..."
-apt-get install -y puppet >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install puppet >/dev/null
 
 echo "Puppet installed!"
 


### PR DESCRIPTION
The install process breaks if a `/etc/puppet/puppet.conf` file already exists (say, because you've mounted `/etc/puppet` as a shared folder) as it hangs on a dialog asking the user to chose to retain or replace the existing configuration.

``` shell
Configuration file `/etc/puppet/puppet.conf'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** puppet.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing puppet-common (--configure):
 EOF on stdin at conffile prompt
dpkg: dependency problems prevent configuration of puppet:
 puppet depends on puppet-common (= 3.5.1-1puppetlabs1); however:
  Package puppet-common is not configured yet.
dpkg: error processing puppet (--configure):
 dependency problems - leaving unconfigured
No apport report written because the error message indicates its a followup error from a previous failure.
Errors were encountered while processing:
 puppet-common
 puppet
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

These changes to the Debian and Ubuntu scripts will skip this dialog and retain the existing configuration file.
