### PR TITLE
Ensuring the most recent stable puppet release on ubuntu

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -17,7 +17,7 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-if which puppet > /dev/null 2>&1; then
+if which puppet > /dev/null 2>&1 -a apt-cache policy | grep --quiet apt.puppetlabs.com; then
   echo "Puppet is already installed."
   exit 0
 fi


### PR DESCRIPTION
The `ubuntu/trusty64` box, comes with puppet pre installed. The bootstrap script quits when encountered, hence you're stuck with the ubuntu stock release version of puppet.

Now the script only exits when puppet was installed from apt.puppetlabs.com.
