### PR TITLE
More reliable way to test if Puppet is installed on Ubuntu

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 #
-# This bootstraps Puppet on Ubuntu 12.04 LTS.
+# This bootstraps Puppet on Ubuntu 14.04 LTS.
 #
 set -e
 
+function installPackage {
+  if DEBIAN_FRONTEND=noninteractive bash -c "apt-get -qq -y ${2} install ${1}" >/dev/null; then
+    echo "Successfully installed package ${1}"
+  else
+    echo "Error installing package ${1}"
+  fi
+}
 # Load up the release information
 . /etc/lsb-release
 
@@ -17,7 +24,8 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-if which puppet > /dev/null 2>&1 -a apt-cache policy | grep --quiet apt.puppetlabs.com; then
+pkg=puppet
+if dpkg --get-selections | grep -q "^$pkg[[:space:]]*install$" >/dev/null; then
   echo "Puppet is already installed."
   exit 0
 fi
@@ -28,7 +36,7 @@ apt-get update >/dev/null
 
 # Install wget if we have to (some older Ubuntu versions)
 echo "Installing wget..."
-apt-get install -y wget >/dev/null
+installPackage 'wget'
 
 # Install the PuppetLabs repo
 echo "Configuring PuppetLabs repo..."
@@ -39,14 +47,12 @@ apt-get update >/dev/null
 
 # Install Puppet
 echo "Installing Puppet..."
-DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install puppet >/dev/null
-
-echo "Puppet installed!"
+installPackage 'puppet' "-o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\""
 
 # Install RubyGems for the provider
 echo "Installing RubyGems..."
 if [ $DISTRIB_CODENAME != "trusty" ]; then
-  apt-get install -y rubygems >/dev/null
+  installPackage 'rubygems'
 fi
 gem install --no-ri --no-rdoc rubygems-update
 update_rubygems >/dev/null

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -11,6 +11,12 @@ function installPackage {
     echo "Error installing package ${1}"
   fi
 }
+
+function isPackageInstalled {
+  if dpkg --get-selections | grep -q "^${1}[[:space:]]*install$" >/dev/null; then
+    echo "Package ${1} is already installed."
+  fi
+}
 # Load up the release information
 . /etc/lsb-release
 
@@ -24,20 +30,20 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-pkg=puppet
-if dpkg --get-selections | grep -q "^$pkg[[:space:]]*install$" >/dev/null; then
-  echo "Puppet is already installed."
+test=$(isPackageInstalled "puppet")
+if [ -n  "$test" ]; then
   exit 0
 fi
 
-# Do the initial apt-get update
-echo "Initial apt-get update..."
-apt-get update >/dev/null
-
 # Install wget if we have to (some older Ubuntu versions)
-echo "Installing wget..."
-installPackage 'wget'
-
+test=$(isPackageInstalled "wget")
+if [ -z  "$test" ]; then
+  # Do the initial apt-get update
+  echo "Initial apt-get update..."
+  apt-get update >/dev/null
+  echo "Installing wget..."
+  installPackage 'wget'
+fi
 # Install the PuppetLabs repo
 echo "Configuring PuppetLabs repo..."
 repo_deb_path=$(mktemp)


### PR DESCRIPTION
Current script will fail to detect that Puppet from the default Ubuntu repositories is installed.
```bash
vagrant@localhost:~$ puppet --version
3.4.3
vagrant@localhost:~$ if which puppet > /dev/null 2>&1 -a apt-cache policy | grep --quiet apt.puppetlabs.com; then   echo "Puppet is already installed."; else  echo "Puppet is NOT installed"; fi
Puppet is NOT installed
vagrant@localhost:~$ pkg=puppet
vagrant@localhost:~$ if dpkg --get-selections | grep -q "^$pkg[[:space:]]*install$" >/dev/null; then   echo "Puppet is already installed.";  else echo "Puppet is NOT installed"; fi
Puppet is already installed.
vagrant@localhost:~$ exit
logout
Connection to 127.0.0.1 closed.
```

I used a more reliable way to determine if a package is installed or not. Solution is based on [the answer](http://askubuntu.com/questions/319307/reliably-check-if-a-package-is-installed-or-not) [enzotib](http://askubuntu.com/users/2647/enzotib) provided on Ask Ubuntu.