### PR TITLE
Updates puppet default version and fixes null test issue

### DIFF
--- a/windows.ps1
+++ b/windows.ps1
@@ -21,11 +21,11 @@
     This defaults to $null.
 #>
 param(
-   [string]$MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-3.3.2.msi"
+   [string]$MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-3.7.3-x64.msi"
   ,[string]$PuppetVersion = $null
 )
 
-if ($PuppetVersion -ne $null) {
+if ($PuppetVersion) {
   $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-$($PuppetVersion).msi"
   Write-Host "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
 }


### PR DESCRIPTION
I am trying to use this with a vagrant box but ran into an issue where the PuppetVersion was not set to null even though I didn't specify it in my vagrant file. I switched the test to simply check for null or empty (which is default if() behavior when you simply state a string in powershell):

```ruby
  #Install Puppet
  config.vm.provision "shell", path: "install-puppet.ps1"
```

Run Error:

```
==> default: Running provisioner: shell...
    default: Running: c:\tmp\vagrant-shell.ps1
==> default: Puppet version  specified, updated MsiUrl to "https://downloads.puppetlabs.com/windows/puppet-.msi"
==> default: Puppet is not installed, continuing...
==> default: 
==> default: Installing Puppet. Running msiexec.exe /qn /norestart /i https://downloads.puppetlabs.com/windows/puppet-.msi
==> default: Installer failed.
An error occurred executing a remote WinRM command.

Shell: powershell
Command: powershell -executionpolicy bypass -file c:\tmp\vagrant-shell.ps1
Message: Command execution failed with an exit code of 1
```

This change allows for a successful run with this script.