### PR TITLE
Minor fix for checking if Puppet has already been installed on Ubuntu

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -17,7 +17,7 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-if which puppet > /dev/null 2>&1 -a apt-cache policy | grep --quiet apt.puppetlabs.com; then
+if which puppet > /dev/null 2>&1 && apt-cache policy | grep --quiet apt.puppetlabs.com; then
   echo "Puppet is already installed."
   exit 0
 fi


### PR DESCRIPTION
This is a similar fix as to #34 but a more minor change to correct the problem.

Also relates to issue #15 