### PR TITLE
fixing check for puppetversion input

### DIFF
--- a/windows.ps1
+++ b/windows.ps1
@@ -25,7 +25,7 @@ param(
   ,[string]$PuppetVersion = $null
 )
 
-if ($PuppetVersion -ne $null) {
+if ($PuppetVersion) {
   $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-$($PuppetVersion).msi"
   Write-Host "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
 }


### PR DESCRIPTION
When trying this against a Win2012r2 image, I was not able to get the comparison to work.