### PR TITLE
Use default if version is empty

### DIFF
--- a/windows.ps1
+++ b/windows.ps1
@@ -25,7 +25,7 @@ param(
   ,[string]$PuppetVersion = $null
 )
 
-if ($PuppetVersion -ne $null) {
+if (($PuppetVersion -ne $null) -and ($PuppetVersion -ne "")) {
   $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-$($PuppetVersion).msi"
   Write-Host "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
 }


### PR DESCRIPTION
In some cases when puppet version is not properly passed (Vagrant 1.7.4) we have:
Puppet version  specified, updated MsiUrl to "https://downloads.puppetlabs.com/windows/puppet-.msi"

So if puppet version is empty the default version is used.