### PR TITLE
Trying out puppet 4 on ubuntu

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -2,12 +2,18 @@
 #
 # This bootstraps Puppet on Ubuntu 12.04 LTS.
 #
+# To try puppet 4 -->  PUPPET_COLLECTION=pc1 ./ubuntu.sh
+#
 set -e
 
 # Load up the release information
 . /etc/lsb-release
 
-REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release-${DISTRIB_CODENAME}.deb"
+# if PUPPET_COLLECTION is not prepended with a dash "-", add it
+[[ "${PUPPET_COLLECTION}" == "" ]] || [[ "${PUPPET_COLLECTION:0:1}" == "-" ]] || \
+  PUPPET_COLLECTION="-${PUPPET_COLLECTION}"
+
+REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release${PUPPET_COLLECTION}-${DISTRIB_CODENAME}.deb"
 
 #--------------------------------------------------------------------
 # NO TUNABLES BELOW THIS POINT

--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -12,6 +12,7 @@ set -e
 # if PUPPET_COLLECTION is not prepended with a dash "-", add it
 [[ "${PUPPET_COLLECTION}" == "" ]] || [[ "${PUPPET_COLLECTION:0:1}" == "-" ]] || \
   PUPPET_COLLECTION="-${PUPPET_COLLECTION}"
+[[ "${PUPPET_COLLECTION}" == "" ]] && PINST="puppet" || PINST="puppet-agent"
 
 REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release${PUPPET_COLLECTION}-${DISTRIB_CODENAME}.deb"
 
@@ -45,7 +46,7 @@ apt-get update >/dev/null
 
 # Install Puppet
 echo "Installing Puppet..."
-DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install puppet >/dev/null
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install ${PINST} >/dev/null
 
 echo "Puppet installed!"
 


### PR DESCRIPTION
This adds support for trying out puppet 4 with the upstream APT repo provided by puppetlabs.  I've had success using puppet 4.  Might be useful to others.   Obviously this is optional and defaults to puppet 3.x repos...