### PR TITLE
update freebsd.sh (freebsd 10.3, puppet4)

### DIFF
--- a/freebsd.sh
+++ b/freebsd.sh
@@ -3,18 +3,9 @@
 set -e
 
 # This bootstraps Puppet on FreeBSD
-
-if [ `sysctl -n kern.osreldate` -ge '901000' ] && pkg -N 2> /dev/null ; then
-  have_pkg=true;
-else
-  have_pkg=false;
-fi
-
 echo "Installing Puppet & dependencies..."
-if $have_pkg; then
-	export ASSUME_ALWAYS_YES=yes
-	pkg install "sysutils/puppet4"
-	unset ASSUME_ALWAYS_YES
+if [ `sysctl -n kern.osreldate` -ge '901000' ] && pkg -N 2> /dev/null ; then
+	pkg install -y "sysutils/puppet4"
 else
 	pkg_add -r puppet
 fi

--- a/freebsd.sh
+++ b/freebsd.sh
@@ -4,7 +4,7 @@ set -e
 
 # This bootstraps Puppet on FreeBSD
 
-if [ `sysctl -n kern.osreldate` -ge '90100' ] && pkg -N 2> /dev/null ; then
+if [ `sysctl -n kern.osreldate` -ge '901000' ] && pkg -N 2> /dev/null ; then
   have_pkg=true;
 else
   have_pkg=false;

--- a/freebsd.sh
+++ b/freebsd.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env sh
 
+set -e
+
 # This bootstraps Puppet on FreeBSD
 
-have_pkg=`grep -sc '^WITH_PKGNG' /etc/make.conf`
+if [ `sysctl -n kern.osreldate` -ge '90100' ] && pkg -N 2> /dev/null ; then
+  have_pkg=true;
+else
+  have_pkg=false;
+fi
 
 echo "Installing Puppet & dependencies..."
-if [ "$have_pkg" = 1 ]
-then
+if $have_pkg; then
 	export ASSUME_ALWAYS_YES=yes
-	pkg install sysutils/puppet
+	pkg install "sysutils/puppet4"
 	unset ASSUME_ALWAYS_YES
 else
 	pkg_add -r puppet


### PR DESCRIPTION
Freesh installation of FreeBSD 10 seems to have no ``/etc/make.conf`` (no ports installed?). Also, it has no ``pkg_add`` anymore. Puppet port origins have form ``sysutils/puppet38``, ``sysutils/puppet4`` and so on. This patch was tested manually on a FreeBSD 10.3 vagrant box:

```
Vagrant.configure(2) do |config|
  config.vm.guest = :freebsd
  config.vm.base_mac = "5CA1AB1E0001"
  config.vm.network "private_network", :bridge => 'enp4s0', :mac => "5CA1AB1E0001", :ip => "10.0.1.11"
  config.vm.box = "freebsd/FreeBSD-10.3-RELEASE"
  config.vm.provider :virtualbox do |vb, override|
    vb.customize ["modifyvm", :id, "--memory", "512"]
    vb.customize ["modifyvm", :id, "--cpus", "2"]
    vb.customize ["modifyvm", :id, "--hwvirtex", "on"]
    vb.customize ["modifyvm", :id, "--audio", "none"]
    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
  end
end
```