### PR TITLE
ignore error when puppetlabs repo already installed

### DIFF
--- a/centos_7_x.sh
+++ b/centos_7_x.sh
@@ -2,8 +2,6 @@
 # This bootstraps Puppet on CentOS 7.x
 # It has been tested on CentOS 7.0 64bit
 
-set -e
-
 REPO_URL="http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm"
 
 if [ "$EUID" -ne "0" ]; then


### PR DESCRIPTION
when `set -e` defined, execution stopped when script found that puppetlabs repo already installed causing `puppet` package to be not installed. 